### PR TITLE
Make all scene objects `Equatable`

### DIFF
--- a/Sources/ScintillaLib/Camera.swift
+++ b/Sources/ScintillaLib/Camera.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Camera {
+public struct Camera: Equatable {
     var horizontalSize: Int
     var verticalSize: Int
     var fieldOfView: Double
@@ -61,5 +61,16 @@ public struct Camera {
         self.halfHeight = halfHeight
         self.pixelSize = pixelSize
         self.antialiasing = antialiasing
+    }
+
+    public static func == (lhs: Camera, rhs: Camera) -> Bool {
+        return (lhs.horizontalSize == rhs.horizontalSize) &&
+               (lhs.verticalSize == rhs.verticalSize) &&
+               (lhs.fieldOfView == rhs.fieldOfView) &&
+               (lhs.viewTransform == rhs.viewTransform) &&
+               (lhs.inverseViewTransform == rhs.inverseViewTransform) &&
+               (lhs.halfWidth == rhs.halfWidth) &&
+               (lhs.halfHeight == rhs.halfHeight) &&
+               (lhs.antialiasing == rhs.antialiasing)
     }
 }

--- a/Sources/ScintillaLib/Color.swift
+++ b/Sources/ScintillaLib/Color.swift
@@ -46,7 +46,7 @@ public enum ColorSpace {
     }
 }
 
-public struct Color {
+public struct Color: Equatable {
     var r: Double
     var g: Double
     var b: Double

--- a/Sources/ScintillaLib/Light.swift
+++ b/Sources/ScintillaLib/Light.swift
@@ -13,7 +13,7 @@ public protocol Light {
     var fadeDistance: Double? { get }
 }
 
-public struct PointLight: Light {
+public struct PointLight: Light, Equatable {
     public var position: Point
     public var color: Color
     public var fadeDistance: Double?
@@ -23,9 +23,15 @@ public struct PointLight: Light {
         self.color = color
         self.fadeDistance = fadeDistance
     }
+
+    public static func == (lhs: PointLight, rhs: PointLight) -> Bool {
+        return (lhs.position == rhs.position) &&
+               (lhs.color == rhs.color) &&
+               (lhs.fadeDistance == rhs.fadeDistance)
+    }
 }
 
-public struct AreaLight: Light {
+public struct AreaLight: Light, Equatable {
     public var position: Point
     public var color: Color
     public var fadeDistance: Double?
@@ -57,6 +63,18 @@ public struct AreaLight: Light {
             .add(self.vVec.multiply(Double(vSteps/2)))
         self.jitter = jitter
         self.fadeDistance = fadeDistance
+    }
+
+    public static func == (lhs: AreaLight, rhs: AreaLight) -> Bool {
+        return (lhs.position == rhs.position) &&
+               (lhs.color == rhs.color) &&
+               (lhs.fadeDistance == rhs.fadeDistance) &&
+               (lhs.corner == rhs.corner) &&
+               (lhs.uVec == rhs.uVec) &&
+               (lhs.uSteps == rhs.uSteps) &&
+               (lhs.vVec == rhs.vVec) &&
+               (lhs.vSteps == rhs.vSteps) &&
+               (lhs.samples == rhs.samples)
     }
 
     public mutating func pointAt(_ u: Int, _ v: Int) -> Point {

--- a/Sources/ScintillaLib/Matrix.swift
+++ b/Sources/ScintillaLib/Matrix.swift
@@ -159,7 +159,7 @@ public struct Matrix3 {
     }
 }
 
-public struct Matrix4 {
+public struct Matrix4: Equatable {
     var data: (
         Double, Double, Double, Double,
         Double, Double, Double, Double,
@@ -185,6 +185,25 @@ public struct Matrix4 {
             x2, y2, z2, w2,
             x3, y3, z3, w3
         )
+    }
+
+    public static func == (lhs: Matrix4, rhs: Matrix4) -> Bool {
+        return (lhs.data.0 == rhs.data.0) &&
+               (lhs.data.1 == rhs.data.1) &&
+               (lhs.data.2 == rhs.data.2) &&
+               (lhs.data.3 == rhs.data.3) &&
+               (lhs.data.4 == rhs.data.4) &&
+               (lhs.data.5 == rhs.data.5) &&
+               (lhs.data.6 == rhs.data.6) &&
+               (lhs.data.7 == rhs.data.7) &&
+               (lhs.data.8 == rhs.data.8) &&
+               (lhs.data.9 == rhs.data.9) &&
+               (lhs.data.10 == rhs.data.10) &&
+               (lhs.data.11 == rhs.data.11) &&
+               (lhs.data.12 == rhs.data.12) &&
+               (lhs.data.13 == rhs.data.13) &&
+               (lhs.data.14 == rhs.data.14) &&
+               (lhs.data.15 == rhs.data.15)
     }
 
     public static func translation(_ x: Double, _ y: Double, _ z: Double) -> Self {

--- a/Sources/ScintillaLib/Tuple.swift
+++ b/Sources/ScintillaLib/Tuple.swift
@@ -57,11 +57,18 @@ extension Tuple4 {
     }
 }
 
-public struct Point: Tuple4 {
+public struct Point: Tuple4, Equatable {
     public var data: (Double, Double, Double, Double)
 
     public init(_ x: Double, _ y: Double, _ z: Double) {
         self.data = (x, y, z, 1.0)
+    }
+
+    public static func == (lhs: Point, rhs: Point) -> Bool {
+        return (lhs.data.0 == rhs.data.0) &&
+               (lhs.data.1 == rhs.data.1) &&
+               (lhs.data.2 == rhs.data.2) &&
+               (lhs.data.3 == rhs.data.3)
     }
 
     @_spi(Testing) public func add(_ other: Vector) -> Point {
@@ -97,11 +104,18 @@ public struct Point: Tuple4 {
     }
 }
 
-public struct Vector: Tuple4 {
+public struct Vector: Tuple4, Equatable {
     public var data: (Double, Double, Double, Double)
 
     public init(_ x: Double, _ y: Double, _ z: Double) {
         self.data = (x, y, z, 0.0)
+    }
+
+    public static func == (lhs: Vector, rhs: Vector) -> Bool {
+        return (lhs.data.0 == rhs.data.0) &&
+               (lhs.data.1 == rhs.data.1) &&
+               (lhs.data.2 == rhs.data.2) &&
+               (lhs.data.3 == rhs.data.3)
     }
 
     @_spi(Testing) public func add(_ other: Vector) -> Vector {


### PR DESCRIPTION
This was necessary to allow ScintillaApp be able to compare all scene objects... and `Camera` and all `Light` types were not yet `Equatable`