### PR TITLE
Make all `Shape` types `Equatable`

### DIFF
--- a/Sources/ScintillaLib/CSG.swift
+++ b/Sources/ScintillaLib/CSG.swift
@@ -11,10 +11,10 @@ public struct CSG: Shape {
     public var sharedProperties: SharedShapeProperties = SharedShapeProperties()
 
     var operation: Operation
-    var left: Shape
-    var right: Shape
+    var left: any Shape
+    var right: any Shape
 
-    public init(_ operation: Operation, _ left: Shape, _ right: Shape) {
+    public init(_ operation: Operation, _ left: any Shape, _ right: any Shape) {
         self.operation = operation
         self.left = left
         self.right = right
@@ -23,7 +23,7 @@ public struct CSG: Shape {
         self.right.parentId = self.id
     }
 
-    public func findShape(_ shapeId: UUID) -> Shape? {
+    public func findShape(_ shapeId: UUID) -> (any Shape)? {
         for shape in [self.left, self.right] {
             if shape.id == shapeId {
                 return shape
@@ -46,7 +46,7 @@ public struct CSG: Shape {
         return nil
     }
 
-    static func makeCSG(_ operation: Operation, _ baseShape: Shape, @ShapeBuilder _ otherShapesBuilder: () -> [Shape]) -> Shape {
+    static func makeCSG(_ operation: Operation, _ baseShape: any Shape, @ShapeBuilder _ otherShapesBuilder: () -> [any Shape]) -> any Shape {
         let rightShapes = otherShapesBuilder()
 
         return rightShapes.reduce(baseShape) { partialResult, rightShape in

--- a/Sources/ScintillaLib/ColorFunction.swift
+++ b/Sources/ScintillaLib/ColorFunction.swift
@@ -36,7 +36,7 @@ public struct ColorFunction: Material {
         return copy
     }
 
-    public func colorAt( _ object: Shape, _ worldPoint: Point) -> Color {
+    public func colorAt( _ object: any Shape, _ worldPoint: Point) -> Color {
         let objectPoint = object.inverseTransform.multiply(worldPoint)
         let colorFunctionPoint = self.inverseTransform.multiply(objectPoint)
         return self.colorAt(colorFunctionPoint)

--- a/Sources/ScintillaLib/Computations.swift
+++ b/Sources/ScintillaLib/Computations.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct Computations {
     @_spi(Testing) public var t: Double
-    @_spi(Testing) public var object: Shape
+    @_spi(Testing) public var object: any Shape
     @_spi(Testing) public var point: Point
     @_spi(Testing) public var overPoint: Point
     @_spi(Testing) public var underPoint: Point

--- a/Sources/ScintillaLib/Group.swift
+++ b/Sources/ScintillaLib/Group.swift
@@ -9,9 +9,9 @@ import Foundation
 
 public struct Group: Shape {
     public var sharedProperties: SharedShapeProperties = SharedShapeProperties()
-    var children: [Shape] = []
+    var children: [any Shape] = []
 
-    public init(@ShapeBuilder builder: () -> [Shape]) {
+    public init(@ShapeBuilder builder: () -> [any Shape]) {
         let children = builder()
         for var child in children {
             child.parentId = self.id
@@ -19,7 +19,7 @@ public struct Group: Shape {
         }
     }
 
-    public func findShape(_ shapeId: UUID) -> Shape? {
+    public func findShape(_ shapeId: UUID) -> (any Shape)? {
         for shape in self.children {
             if shape.id == shapeId {
                 return shape

--- a/Sources/ScintillaLib/ImplicitSurface.swift
+++ b/Sources/ScintillaLib/ImplicitSurface.swift
@@ -18,7 +18,7 @@ public struct ImplicitSurface: Shape {
     public var sharedProperties: SharedShapeProperties = SharedShapeProperties()
 
     var f: SurfaceFunction
-    var boundingShape: Shape
+    var boundingShape: any Shape
 
     // This constructor is for creating an implicit surface with a bounding
     // sphere with the specified center and radius
@@ -45,7 +45,7 @@ public struct ImplicitSurface: Shape {
 
     // This constructor is for creating an implicit surface with the
     // specified bounding shape
-    public init(shape: Shape, _ f: @escaping SurfaceFunction) {
+    public init(shape: any Shape, _ f: @escaping SurfaceFunction) {
         self.boundingShape = shape
         self.f = f
     }

--- a/Sources/ScintillaLib/Intersection.swift
+++ b/Sources/ScintillaLib/Intersection.swift
@@ -9,14 +9,14 @@ import Foundation
 
 public struct Intersection {
     @_spi(Testing) public var t: Double
-    @_spi(Testing) public var shape: Shape
+    @_spi(Testing) public var shape: any Shape
     @_spi(Testing) public var uv: UV
 
-    @_spi(Testing) public init(_ t: Double, _ shape: Shape) {
+    @_spi(Testing) public init(_ t: Double, _ shape: any Shape) {
         self.init(t, .none, shape)
     }
 
-    @_spi(Testing) public init(_ t: Double, _ uv: UV, _ shape: Shape) {
+    @_spi(Testing) public init(_ t: Double, _ uv: UV, _ shape: any Shape) {
         self.t = t
         self.shape = shape
         self.uv = uv
@@ -25,7 +25,7 @@ public struct Intersection {
     func computeRefractiveIndices(_ allIntersections: [Intersection]) -> (Double, Double) {
         var n1 = 1.0
         var n2 = 1.0
-        var containers: [Shape] = []
+        var containers: [any Shape] = []
         for intersection in allIntersections {
             if intersection.t == self.t {
                 if let lastContainer = containers.last {

--- a/Sources/ScintillaLib/Material.swift
+++ b/Sources/ScintillaLib/Material.swift
@@ -38,7 +38,7 @@ public struct MaterialProperties {
 
 public protocol Material {
     func copy() -> Self
-    func colorAt(_ object: Shape, _ worldPoint: Point) -> Color
+    func colorAt(_ object: any Shape, _ worldPoint: Point) -> Color
     var properties: MaterialProperties { get set }
 }
 
@@ -99,7 +99,7 @@ extension Material {
         return modifyingProperties { $0.refractive = refractive }
     }
 
-    @_spi(Testing) public func lighting(_ light: Light, _ object: Shape, _ point: Point, _ eye: Vector, _ normal: Vector, _ intensity: Double) -> Color {
+    @_spi(Testing) public func lighting(_ light: Light, _ object: any Shape, _ point: Point, _ eye: Vector, _ normal: Vector, _ intensity: Double) -> Color {
         // Account for the attenuation of the light source over distance
         // if it has the fadeDistance property set. This is very similar
         // to the approach that POV-Ray uses, documented here:

--- a/Sources/ScintillaLib/ParametricSurface.swift
+++ b/Sources/ScintillaLib/ParametricSurface.swift
@@ -34,7 +34,7 @@ public struct ParametricSurface: Shape {
     var fx: ParametricFunction
     var fy: ParametricFunction
     var fz: ParametricFunction
-    var boundingShape: Shape
+    var boundingShape: any Shape
     var uRange: (Double, Double)
     var vRange: (Double, Double)
     var accuracy: Double
@@ -89,7 +89,7 @@ public struct ParametricSurface: Shape {
 
     // This constructor constructs a parametric surface is the same as
     // the above but with a bounding shape instead
-    public init(shape: Shape,
+    public init(shape: any Shape,
                 uRange: (Double, Double),
                 vRange: (Double, Double),
                 accuracy: Double,

--- a/Sources/ScintillaLib/Pattern.swift
+++ b/Sources/ScintillaLib/Pattern.swift
@@ -21,7 +21,7 @@ open class Pattern: Material {
         fatalError("Subclasses must override this method!")
     }
 
-    public func colorAt( _ object: Shape, _ worldPoint: Point) -> Color {
+    public func colorAt( _ object: any Shape, _ worldPoint: Point) -> Color {
         let objectPoint = object.inverseTransform.multiply(worldPoint)
         let patternPoint = self.inverseTransform.multiply(objectPoint)
         return self.colorAt(patternPoint)

--- a/Sources/ScintillaLib/Shape.swift
+++ b/Sources/ScintillaLib/Shape.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol Shape {
+public protocol Shape: Equatable {
     var sharedProperties: SharedShapeProperties { get set }
 
     func localIntersect(_ localRay: Ray) -> [Intersection]
@@ -56,17 +56,23 @@ extension Shape {
     }
 }
 
+extension Shape {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs.id == rhs.id
+    }
+}
+
 // CSG extensions
 extension Shape {
-    public func union(@ShapeBuilder _ otherShapesBuilder: () -> [Shape]) -> Shape {
+    public func union(@ShapeBuilder _ otherShapesBuilder: () -> [any Shape]) -> any Shape {
         return CSG.makeCSG(.union, self, otherShapesBuilder)
     }
 
-    public func difference(@ShapeBuilder _ otherShapesBuilder: () -> [Shape]) -> Shape {
+    public func difference(@ShapeBuilder _ otherShapesBuilder: () -> [any Shape]) -> any Shape {
         return CSG.makeCSG(.difference, self, otherShapesBuilder)
     }
 
-    public func intersection(@ShapeBuilder _ otherShapesBuilder: () -> [Shape]) -> Shape {
+    public func intersection(@ShapeBuilder _ otherShapesBuilder: () -> [any Shape]) -> any Shape {
         return CSG.makeCSG(.intersection, self, otherShapesBuilder)
     }
 }
@@ -190,7 +196,7 @@ extension Shape {
         return worldNormal
     }
 
-    func includes(_ other: Shape) -> Bool {
+    func includes(_ other: any Shape) -> Bool {
         switch self {
         case let group as Group:
             return group.children.contains(where: {shape in shape.includes(other)})

--- a/Sources/ScintillaLib/ShapeBuilder.swift
+++ b/Sources/ScintillaLib/ShapeBuilder.swift
@@ -9,15 +9,15 @@ import Foundation
 
 @resultBuilder
 public enum ShapeBuilder {
-    public static func buildBlock(_ components: [Shape]...) -> [Shape] {
+    public static func buildBlock(_ components: [any Shape]...) -> [any Shape] {
         return Array(components.joined())
     }
 
-    public static func buildExpression(_ expression: Shape) -> [Shape] {
+    public static func buildExpression(_ expression: any Shape) -> [any Shape] {
         return [expression]
     }
 
-    public static func buildArray(_ components: [[Shape]]) -> [Shape] {
+    public static func buildArray(_ components: [[any Shape]]) -> [any Shape] {
         return Array(components.joined())
     }
 }

--- a/Sources/ScintillaLib/SolidColor.swift
+++ b/Sources/ScintillaLib/SolidColor.swift
@@ -18,7 +18,7 @@ public struct SolidColor: Material {
         self.color = colorSpace.makeColor(component1, component2, component3)
     }
 
-    public func colorAt(_ object: Shape, _ worldPoint: Point) -> Color {
+    public func colorAt(_ object: any Shape, _ worldPoint: Point) -> Color {
         return color
     }
 

--- a/Sources/ScintillaLib/World.swift
+++ b/Sources/ScintillaLib/World.swift
@@ -12,7 +12,7 @@ import Foundation
 public actor World {
     @_spi(Testing) public var camera: Camera
     @_spi(Testing) public var lights: [Light]
-    @_spi(Testing) public var shapes: [Shape]
+    @_spi(Testing) public var shapes: [any Shape]
 
     var totalPixels: Int
 
@@ -20,7 +20,7 @@ public actor World {
         let (camera, objects) = builder()
 
         var lights: [Light] = []
-        var shapes: [Shape] = []
+        var shapes: [any Shape] = []
         for object in objects {
             switch object {
             case .light(let light):
@@ -39,7 +39,7 @@ public actor World {
     public init(_ camera: Camera, @WorldObjectBuilder builder: () -> [WorldObject]) {
         let objects = builder()
         var lights: [Light] = []
-        var shapes: [Shape] = []
+        var shapes: [any Shape] = []
         for object in objects {
             switch object {
             case .light(let light):
@@ -55,14 +55,14 @@ public actor World {
         self.totalPixels = camera.horizontalSize * camera.verticalSize
     }
 
-    public init(_ camera: Camera, _ lights: [Light], _ shapes: [Shape]) {
+    public init(_ camera: Camera, _ lights: [Light], _ shapes: [any Shape]) {
         self.camera = camera
         self.lights = lights
         self.shapes = shapes
         self.totalPixels = camera.horizontalSize * camera.verticalSize
     }
 
-    public func findShape(_ shapeId: UUID) -> Shape? {
+    public func findShape(_ shapeId: UUID) -> (any Shape)? {
         for shape in self.shapes {
             if shape.id == shapeId {
                 return shape

--- a/Sources/ScintillaLib/WorldBuilder.swift
+++ b/Sources/ScintillaLib/WorldBuilder.swift
@@ -23,7 +23,7 @@ public enum WorldBuilder {
         return [.light(light)]
     }
 
-    public static func buildExpression(_ shape: Shape) -> [WorldObject] {
+    public static func buildExpression(_ shape: any Shape) -> [WorldObject] {
         return [.shape(shape)]
     }
 

--- a/Sources/ScintillaLib/WorldObject.swift
+++ b/Sources/ScintillaLib/WorldObject.swift
@@ -7,5 +7,5 @@
 
 public enum WorldObject {
     case light(Light)
-    case shape(Shape)
+    case shape(any Shape)
 }

--- a/Sources/ScintillaLib/WorldObjectBuilder.swift
+++ b/Sources/ScintillaLib/WorldObjectBuilder.swift
@@ -17,7 +17,7 @@ public enum WorldObjectBuilder {
         return [.light(light)]
     }
 
-    public static func buildExpression(_ shape: Shape) -> [WorldObject] {
+    public static func buildExpression(_ shape: any Shape) -> [WorldObject] {
         return [.shape(shape)]
     }
 


### PR DESCRIPTION
For shapes we should now be able to compare by the internal `id` property. In order to accomplish that, we needed to change the signatures and types of many things in the rest of the code base to use `any Shape` instead of `Shape`.