### PR TITLE
Needed to create standalone `==` function

### DIFF
--- a/Sources/ScintillaLib/Shape.swift
+++ b/Sources/ScintillaLib/Shape.swift
@@ -207,3 +207,7 @@ extension Shape {
         }
     }
 }
+
+public func == (lhs: any Shape, rhs: any Shape) -> Bool {
+    return lhs.id == rhs.id
+}


### PR DESCRIPTION
Comparison of two existential `Shape` types won't work with standard conformance to `Equatable` defined in an extension.