### PR TITLE
Make `Sphere` a struct and fix bug involving CSGs

### DIFF
--- a/Examples/TestDie/TestDie.swift
+++ b/Examples/TestDie/TestDie.swift
@@ -1,0 +1,54 @@
+//
+//  TestDie.swift
+//  ScintillaLib
+//
+//  Created by Danielle Kefford on 1/31/25.
+//
+
+import ScintillaLib
+
+@available(macOS 12.0, *)
+@main
+struct Die: ScintillaApp {
+    var world: World {
+        let dimple =
+            Sphere()
+                .material(.solidColor(1, 1, 1))
+                .scale(0.2, 0.2, 0.2)
+
+        return World {
+            Camera(width: 800,
+                   height: 600,
+                   viewAngle: PI/3,
+                   from: Point(0, 3, -7),
+                   to: Point(0, 1, 0),
+                   up: Vector(0, 1, 0))
+            PointLight(position: Point(-5, 10, -10))
+            Superellipsoid(e: 0.15, n: 0.15)
+//            Cube()
+                .material(
+                    .solidColor(0.8, 0.5, 0.2, .rgb)
+                    .transparency(1.0)
+                    .shininess(1.0)
+                    .refractive(1.5))
+                .translate(0.0, 1.0, 0.0)
+                .difference {
+                    dimple
+                        .translate(0.0, 2.0, 0.0)
+                    dimple
+                        .translate(1.0, 0.5, -0.5)
+                    dimple
+                        .translate(1.0, 1.0, 0.0)
+                    dimple
+                        .translate(1.0, 1.5, 0.5)
+                    dimple
+                        .translate(-0.5, 1.5, -1.0)
+                    dimple
+                        .translate(0.5, 0.5, -1.0)
+                }
+                .rotateY(PI/4)
+            Plane()
+                .material(.solidColor(0.9, 0.9, 0.9))
+        }
+    }
+}

--- a/Examples/TestDie/TestDie.swift
+++ b/Examples/TestDie/TestDie.swift
@@ -25,7 +25,6 @@ struct Die: ScintillaApp {
                    up: Vector(0, 1, 0))
             PointLight(position: Point(-5, 10, -10))
             Superellipsoid(e: 0.15, n: 0.15)
-//            Cube()
                 .material(
                     .solidColor(0.8, 0.5, 0.2, .rgb)
                     .transparency(1.0)

--- a/Package.swift
+++ b/Package.swift
@@ -108,5 +108,9 @@ let package = Package(
             name: "Wine",
             dependencies: ["ScintillaLib"],
             path: "Examples/Wine"),
+        .executableTarget(
+            name: "TestDie",
+            dependencies: ["ScintillaLib"],
+            path: "Examples/TestDie"),
     ]
 )

--- a/Sources/ScintillaLib/CSG.swift
+++ b/Sources/ScintillaLib/CSG.swift
@@ -20,29 +20,6 @@ public struct CSG: Shape {
         self.right = right
     }
 
-    public func findShape(_ shapeId: ShapeID) -> (any Shape)? {
-        for shape in [self.left, self.right] {
-            if shape.id == shapeId {
-                return shape
-            }
-
-            switch shape {
-            case let csg as CSG:
-                if let shape = csg.findShape(shapeId) {
-                    return shape
-                }
-            case let group as Group:
-                if let shape = group.findShape(shapeId) {
-                    return shape
-                }
-            default:
-                continue
-            }
-        }
-
-        return nil
-    }
-
     static func makeCSG(_ operation: Operation, _ baseShape: any Shape, @ShapeBuilder _ otherShapesBuilder: () -> [any Shape]) -> any Shape {
         let rightShapes = otherShapesBuilder()
 

--- a/Sources/ScintillaLib/CSG.swift
+++ b/Sources/ScintillaLib/CSG.swift
@@ -11,19 +11,16 @@ public struct CSG: Shape {
     public var sharedProperties: SharedShapeProperties = SharedShapeProperties()
 
     var operation: Operation
-    var left: any Shape
-    var right: any Shape
+    @_spi(Testing) public var left: any Shape
+    @_spi(Testing) public var right: any Shape
 
     public init(_ operation: Operation, _ left: any Shape, _ right: any Shape) {
         self.operation = operation
         self.left = left
         self.right = right
-
-        self.left.parentId = self.id
-        self.right.parentId = self.id
     }
 
-    public func findShape(_ shapeId: UUID) -> (any Shape)? {
+    public func findShape(_ shapeId: ShapeID) -> (any Shape)? {
         for shape in [self.left, self.right] {
             if shape.id == shapeId {
                 return shape

--- a/Sources/ScintillaLib/Group.swift
+++ b/Sources/ScintillaLib/Group.swift
@@ -18,29 +18,6 @@ public struct Group: Shape {
         }
     }
 
-    public func findShape(_ shapeId: ShapeID) -> (any Shape)? {
-        for shape in self.children {
-            if shape.id == shapeId {
-                return shape
-            }
-
-            switch shape {
-            case let csg as CSG:
-                if let shape = csg.findShape(shapeId) {
-                    return shape
-                }
-            case let group as Group:
-                if let shape = group.findShape(shapeId) {
-                    return shape
-                }
-            default:
-                continue
-            }
-        }
-
-        return nil
-    }
-
     @_spi(Testing) public func localIntersect(_ localRay: Ray) -> [Intersection] {
         var allIntersections: [Intersection] = []
 

--- a/Sources/ScintillaLib/Group.swift
+++ b/Sources/ScintillaLib/Group.swift
@@ -13,13 +13,12 @@ public struct Group: Shape {
 
     public init(@ShapeBuilder builder: () -> [any Shape]) {
         let children = builder()
-        for var child in children {
-            child.parentId = self.id
+        for child in children {
             self.children.append(child)
         }
     }
 
-    public func findShape(_ shapeId: UUID) -> (any Shape)? {
+    public func findShape(_ shapeId: ShapeID) -> (any Shape)? {
         for shape in self.children {
             if shape.id == shapeId {
                 return shape

--- a/Sources/ScintillaLib/Group.swift
+++ b/Sources/ScintillaLib/Group.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public struct Group: Shape {
     public var sharedProperties: SharedShapeProperties = SharedShapeProperties()
-    var children: [any Shape] = []
+    public var children: [any Shape] = []
 
     public init(@ShapeBuilder builder: () -> [any Shape]) {
         let children = builder()

--- a/Sources/ScintillaLib/SharedShapeProperties.swift
+++ b/Sources/ScintillaLib/SharedShapeProperties.swift
@@ -7,15 +7,25 @@
 
 import Foundation
 
+public typealias ShapeID = [UInt8]
+
 public struct SharedShapeProperties {
     public init() {
         self.inverseTransform = transform.inverse()
         self.inverseTransposeTransform = transform.inverse().transpose()
     }
 
-    @_spi(Testing) public var id: UUID = UUID()
-    public var material: Material = .basicMaterial()
+    @_spi(Testing) public var id: ShapeID = []
+    public var parentID: ShapeID? {
+        if self.id.count == 1 {
+            return nil
+        }
 
+        return self.id.dropLast()
+    }
+
+    public private(set) var inverseTransform: Matrix4
+    public private(set) var inverseTransposeTransform: Matrix4
     public var transform: Matrix4 = .identity {
         didSet {
             self.inverseTransform = transform.inverse()
@@ -23,8 +33,6 @@ public struct SharedShapeProperties {
         }
     }
 
-    public private(set) var inverseTransform: Matrix4
-    public private(set) var inverseTransposeTransform: Matrix4
-    public var parentID: UUID?
+    public var material: Material = .basicMaterial()
     public var castsShadow: Bool = true
 }

--- a/Sources/ScintillaLib/Sphere.swift
+++ b/Sources/ScintillaLib/Sphere.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class Sphere: Shape {
+public struct Sphere: Shape {
     public var sharedProperties: SharedShapeProperties = SharedShapeProperties()
 
     public init() {}

--- a/Sources/ScintillaLib/World.swift
+++ b/Sources/ScintillaLib/World.swift
@@ -75,29 +75,6 @@ public actor World {
         }
     }
 
-    public func findShape(_ shapeId: ShapeID) -> (any Shape)? {
-        for shape in self.shapes {
-            if shape.id == shapeId {
-                return shape
-            }
-
-            switch shape {
-            case let csg as CSG:
-                if let shape = csg.findShape(shapeId) {
-                    return shape
-                }
-            case let group as Group:
-                if let shape = group.findShape(shapeId) {
-                    return shape
-                }
-            default:
-                continue
-            }
-        }
-
-        return nil
-    }
-
     @_spi(Testing) public func intersect(_ ray: Ray) -> [Intersection] {
         var intersections = self.shapes.flatMap({shape in shape.intersect(ray)})
         intersections

--- a/Sources/ScintillaLib/World.swift
+++ b/Sources/ScintillaLib/World.swift
@@ -69,27 +69,25 @@ public actor World {
     }
 
     private func reassignIds() {
-        self.shapes = self.shapes.map { self.reassignId(shape: $0) }
+        self.shapes = self.shapes.map { self.reassignId(shape: $0, parentId: nil) }
     }
 
-    private func reassignId(shape: any Shape) -> any Shape {
+    private func reassignId(shape: any Shape, parentId: UUID?) -> any Shape {
         if var group = shape as? Group {
             group.id = UUID()
-            group.children = group.children.map { self.reassignId(shape: $0) }
-            for var child in group.children {
-                child.parentId = group.id
-            }
+            group.parentId = parentId
+            group.children = group.children.map { self.reassignId(shape: $0, parentId: group.id) }
             return group
         } else if var csg = shape as? CSG {
             csg.id = UUID()
-            csg.left = reassignId(shape: csg.left)
-            csg.left.parentId = csg.id
-            csg.right = reassignId(shape: csg.right)
-            csg.right.parentId = csg.id
+            csg.parentId = parentId
+            csg.left = reassignId(shape: csg.left, parentId: csg.id)
+            csg.right = reassignId(shape: csg.right, parentId: csg.id)
             return csg
         } else {
             var copy = shape
             copy.id = UUID()
+            copy.parentId = parentId
             return copy
         }
     }

--- a/Tests/ScintillaLibTests/CSGTests.swift
+++ b/Tests/ScintillaLibTests/CSGTests.swift
@@ -12,21 +12,25 @@ class CSGTests: XCTestCase {
     func testFilterIntersections() throws {
         let s1 = Sphere()
         let s2 = Cube()
-        let allIntersections = [
-            Intersection(1, s1),
-            Intersection(2, s2),
-            Intersection(3, s1),
-            Intersection(4, s2),
-        ]
-
         let testCases: [(ScintillaLib.Operation, Int, Int)] = [
             (.union, 0, 3),
             (.intersection, 1, 2),
             (.difference, 0, 1),
         ]
+
         for (operation, firstIndex, secondIndex) in testCases {
             let csg = CSG(operation, s1, s2)
-            let filteredIntersections = csg.filterIntersections(allIntersections)
+            let assignedCsg = csg.assignId(id: [0])
+            let assignedS1 = assignedCsg.left
+            let assignedS2 = assignedCsg.right
+            let allIntersections = [
+                Intersection(1, assignedS1),
+                Intersection(2, assignedS2),
+                Intersection(3, assignedS1),
+                Intersection(4, assignedS2),
+            ]
+
+            let filteredIntersections = assignedCsg.filterIntersections(allIntersections)
             XCTAssertEqual(filteredIntersections.count, 2)
             XCTAssertTrue(filteredIntersections[0].t == allIntersections[firstIndex].t)
             XCTAssertTrue(filteredIntersections[1].t == allIntersections[secondIndex].t)
@@ -37,8 +41,9 @@ class CSGTests: XCTestCase {
         let s1 = Sphere()
         let s2 = Cube()
         let csg = CSG(.union, s1, s2)
+        let assignedCsg = csg.assignId(id: [0])
         let ray = Ray(Point(0, 2, -5), Vector(0, 0, 1))
-        let allIntersections = csg.localIntersect(ray)
+        let allIntersections = assignedCsg.localIntersect(ray)
         XCTAssertTrue(allIntersections.isEmpty)
     }
 
@@ -47,12 +52,14 @@ class CSGTests: XCTestCase {
         let s2 = Sphere()
             .translate(0, 0, 0.5)
         let csg = CSG(.union, s1, s2)
+        let assignedCsg = csg.assignId(id: [0])
+
         let ray = Ray(Point(0, 0, -5), Vector(0, 0, 1))
-        let allIntersections = csg.localIntersect(ray)
+        let allIntersections = assignedCsg.localIntersect(ray)
         XCTAssertEqual(allIntersections.count, 2)
         XCTAssertTrue(allIntersections[0].t.isAlmostEqual(4))
-        XCTAssertEqual(allIntersections[0].shape.id, s1.id)
+        XCTAssertEqual(allIntersections[0].shape.id, [0, 0])
         XCTAssertTrue(allIntersections[1].t.isAlmostEqual(6.5))
-        XCTAssertEqual(allIntersections[1].shape.id, s2.id)
+        XCTAssertEqual(allIntersections[1].shape.id, [0, 1])
     }
 }

--- a/Tests/ScintillaLibTests/IntersectionTests.swift
+++ b/Tests/ScintillaLibTests/IntersectionTests.swift
@@ -75,10 +75,11 @@ class IntersectionTests: XCTestCase {
             testCamera
             shape
         }
-        let intersection = Intersection(4, shape)
+        let assignedShape = await world.shapes[0]
+        let intersection = Intersection(4, assignedShape)
         let computations = await intersection.prepareComputations(world, ray, [intersection])
         XCTAssertEqual(computations.t, intersection.t)
-        XCTAssertEqual(computations.object.id, shape.id)
+        XCTAssertEqual(computations.object.id, assignedShape.id)
         XCTAssert(computations.point.isAlmostEqual(Point(0, 0, -1)))
         XCTAssert(computations.eye.isAlmostEqual(Vector(0, 0, -1)))
         XCTAssert(computations.normal.isAlmostEqual(Vector(0, 0, -1)))
@@ -92,10 +93,11 @@ class IntersectionTests: XCTestCase {
             testCamera
             shape
         }
-        let intersection = Intersection(1, shape)
+        let assignedShape = await world.shapes[0]
+        let intersection = Intersection(1, assignedShape)
         let computations = await intersection.prepareComputations(world, ray, [intersection])
         XCTAssertEqual(computations.t, intersection.t)
-        XCTAssertEqual(computations.object.id, shape.id)
+        XCTAssertEqual(computations.object.id, assignedShape.id)
         XCTAssert(computations.point.isAlmostEqual(Point(0, 0, 1)))
         XCTAssert(computations.eye.isAlmostEqual(Vector(0, 0, -1)))
         XCTAssert(computations.normal.isAlmostEqual(Vector(0, 0, -1)))
@@ -110,7 +112,8 @@ class IntersectionTests: XCTestCase {
             testCamera
             shape
         }
-        let intersection = Intersection(5, shape)
+        let assignedShape = await world.shapes[0]
+        let intersection = Intersection(5, assignedShape)
         let computations = await intersection.prepareComputations(world, ray, [intersection])
         XCTAssertTrue(computations.overPoint[2] < -EPSILON/2)
         XCTAssertTrue(computations.point[2] > computations.overPoint[2])
@@ -124,7 +127,8 @@ class IntersectionTests: XCTestCase {
             testCamera
             shape
         }
-        let intersection = Intersection(5, shape)
+        let assignedShape = await world.shapes[0]
+        let intersection = Intersection(5, assignedShape)
         let computations = await intersection.prepareComputations(world, ray, [intersection])
         XCTAssertTrue(computations.underPoint[2] > EPSILON/2)
         XCTAssertTrue(computations.point[2] < computations.underPoint[2])
@@ -136,8 +140,9 @@ class IntersectionTests: XCTestCase {
             testCamera
             shape
         }
+        let assignedShape = await world.shapes[0]
         let ray = Ray(Point(0, 1, -1), Vector(0, -sqrt(2)/2, sqrt(2)/2))
-        let intersection = Intersection(sqrt(2), shape)
+        let intersection = Intersection(sqrt(2), assignedShape)
         let computations = await intersection.prepareComputations(world, ray, [intersection])
         XCTAssertTrue(computations.reflected.isAlmostEqual(Vector(0, sqrt(2)/2, sqrt(2)/2)))
     }
@@ -158,15 +163,18 @@ class IntersectionTests: XCTestCase {
             glassSphereB
             glassSphereC
         }
+        let assignedGlassSphereA = await world.shapes[0]
+        let assignedGlassSphereB = await world.shapes[1]
+        let assignedGlassSphereC = await world.shapes[2]
 
         let ray = Ray(Point(0, 0, -4), Vector(0, 0, 1))
         let allIntersections = [
-            Intersection(2, glassSphereA),
-            Intersection(2.75, glassSphereB),
-            Intersection(3.25, glassSphereC),
-            Intersection(4.75, glassSphereB),
-            Intersection(5.25, glassSphereC),
-            Intersection(6, glassSphereA),
+            Intersection(2, assignedGlassSphereA),
+            Intersection(2.75, assignedGlassSphereB),
+            Intersection(3.25, assignedGlassSphereC),
+            Intersection(4.75, assignedGlassSphereB),
+            Intersection(5.25, assignedGlassSphereC),
+            Intersection(6, assignedGlassSphereA),
         ]
         let expectedValues = [
             (1.0, 1.5),

--- a/Tests/ScintillaLibTests/ShapeTests.swift
+++ b/Tests/ScintillaLibTests/ShapeTests.swift
@@ -17,60 +17,57 @@ class ShapeTests: XCTestCase {
                             up: Vector(0, 1, 0))
 
     func testWorldToObjectForNestedObject() async throws {
-        let s = Sphere()
-            .translate(5, 0, 0)
-
         let world = World {
             testCamera
             Group {
                 Group {
-                    s
+                    Sphere()
+                        .translate(5, 0, 0)
                 }
                     .scale(2, 2, 2)
             }
                 .rotateY(PI/2)
         }
 
+        let s = ((await world.shapes[0] as! Group).children[0] as! Group).children[0] as! Sphere
         let actualValue = await s.worldToObject(world, Point(-2, 0, -10))
         let expectedValue = Point(0, 0, -1)
         XCTAssertTrue(actualValue.isAlmostEqual(expectedValue))
     }
 
     func testObjectToWorldForNestedObject() async throws {
-        let s = Sphere()
-            .translate(5, 0, 0)
-
         let world = World {
             testCamera
             Group {
                 Group {
-                    s
+                    Sphere()
+                        .translate(5, 0, 0)
                 }
                     .scale(1, 2, 3)
             }
                 .rotateY(PI/2)
         }
 
+        let s = ((await world.shapes[0] as! Group).children[0] as! Group).children[0] as! Sphere
         let actualValue = await s.objectToWorld(world, Vector(sqrt(3)/3, sqrt(3)/3, sqrt(3)/3))
         let expectedValue = Vector(0.28571, 0.42857, -0.85714)
         XCTAssertTrue(actualValue.isAlmostEqual(expectedValue))
     }
 
     func testNormalForNestedObject() async throws {
-        let s = Sphere()
-            .translate(5, 0, 0)
-
         let world = World {
             testCamera
             Group {
                 Group {
-                    s
+                    Sphere()
+                        .translate(5, 0, 0)
                 }
                     .scale(1, 2, 3)
             }
                 .rotateY(PI/2)
         }
 
+        let s = ((await world.shapes[0] as! Group).children[0] as! Group).children[0] as! Sphere
         let actualValue = await s.normal(world, Point(1.7321, 1.1547, -5.5774))
         let expectedValue = Vector(0.28570, 0.42854, -0.85716)
         XCTAssertTrue(actualValue.isAlmostEqual(expectedValue))

--- a/Tests/ScintillaLibTests/SphereTests.swift
+++ b/Tests/ScintillaLibTests/SphereTests.swift
@@ -69,73 +69,79 @@ class SphereTests: XCTestCase {
 
     func testNormalPointOnXAxis() async throws {
         let p = Point(1, 0, 0)
-        let s = Sphere()
+        let sphere = Sphere()
         let world = World {
             testCamera
-            s
+            sphere
         }
-        let actualValue = await s.normal(world, p)
+        let assignedSphere = await world.shapes[0]
+        let actualValue = await assignedSphere.normal(world, p)
         let expectedValue = Vector(1, 0, 0)
         XCTAssert(actualValue.isAlmostEqual(expectedValue))
     }
 
     func testNormalPointOnYAxis() async throws {
         let p = Point(0, 1, 0)
-        let s = Sphere()
+        let sphere = Sphere()
         let world = World {
             testCamera
-            s
+            sphere
         }
-        let actualValue = await s.normal(world, p)
+        let assignedSphere = await world.shapes[0]
+        let actualValue = await assignedSphere.normal(world, p)
         let expectedValue = Vector(0, 1, 0)
         XCTAssert(actualValue.isAlmostEqual(expectedValue))
     }
 
     func testNormalPointOnZAxis() async throws {
         let p = Point(0, 0, 1)
-        let s = Sphere()
+        let sphere = Sphere()
         let world = World {
             testCamera
-            s
+            sphere
         }
-        let actualValue = await s.normal(world, p)
+        let assignedSphere = await world.shapes[0]
+        let actualValue = await assignedSphere.normal(world, p)
         let expectedValue = Vector(0, 0, 1)
         XCTAssert(actualValue.isAlmostEqual(expectedValue))
     }
 
     func testNormalNonaxialPoint() async throws {
         let p = Point(sqrt(3)/3, sqrt(3)/3, sqrt(3)/3)
-        let s = Sphere()
+        let sphere = Sphere()
         let world = World {
             testCamera
-            s
+            sphere
         }
-        let actualValue = await s.normal(world, p)
+        let assignedSphere = await world.shapes[0]
+        let actualValue = await assignedSphere.normal(world, p)
         let expectedValue = Vector(sqrt(3)/3, sqrt(3)/3, sqrt(3)/3)
         XCTAssert(actualValue.isAlmostEqual(expectedValue))
     }
 
     func testNormalTranslatedSphere() async throws {
-        let s = Sphere()
+        let sphere = Sphere()
             .translate(0, 1, 0)
         let world = World {
             testCamera
-            s
+            sphere
         }
-        let actualValue = await s.normal(world, Point(0, 1.70711, -0.70711))
+        let assignedSphere = await world.shapes[0]
+        let actualValue = await assignedSphere.normal(world, Point(0, 1.70711, -0.70711))
         let expectedValue = Vector(0, 0.70711, -0.70711)
         XCTAssert(actualValue.isAlmostEqual(expectedValue))
     }
 
     func testNormalTransformedSphere() async throws {
-        let s = Sphere()
+        let sphere = Sphere()
             .scale(1, 0.5, 1)
             .rotateY(PI/5)
         let world = World {
             testCamera
-            s
+            sphere
         }
-        let actualValue = await s.normal(world, Point(0, sqrt(2)/2, -sqrt(2)/2))
+        let assignedSphere = await world.shapes[0]
+        let actualValue = await assignedSphere.normal(world, Point(0, sqrt(2)/2, -sqrt(2)/2))
         let expectedValue = Vector(0, 0.97014, -0.24254)
         XCTAssert(actualValue.isAlmostEqual(expectedValue))
     }

--- a/Tests/ScintillaLibTests/WorldTests.swift
+++ b/Tests/ScintillaLibTests/WorldTests.swift
@@ -703,7 +703,7 @@ class WorldTests: XCTestCase {
     func testRayForPixelForCenterOfCanvas() async throws {
         let camera = Camera(width: 201, height: 101, viewAngle: PI/2, viewTransform: .identity)
         let lights = [PointLight(position: Point(-10, 10, -10))]
-        let shapes: [Shape] = []
+        let shapes: [any Shape] = []
         let world = World(camera, lights, shapes)
 
         let ray = await world.rayForPixel(100, 50)
@@ -714,7 +714,7 @@ class WorldTests: XCTestCase {
     func testRayForPixelForCornerOfCanvas() async throws {
         let camera = Camera(width: 201, height: 101, viewAngle: PI/2, viewTransform: .identity)
         let lights = [PointLight(position: Point(-10, 10, -10))]
-        let objects: [Shape] = []
+        let objects: [any Shape] = []
         let world = World(camera, lights, objects)
 
         let ray = await world.rayForPixel(0, 0)
@@ -727,7 +727,7 @@ class WorldTests: XCTestCase {
             .multiply(.translation(0, -2, 5))
         let camera = Camera(width: 201, height: 101, viewAngle: PI/2, viewTransform: transform)
         let lights = [PointLight(position: Point(-10, 10, -10))]
-        let objects: [Shape] = []
+        let objects: [any Shape] = []
         let world = World(camera, lights, objects)
 
         let ray = await world.rayForPixel(100, 50)

--- a/Tests/ScintillaLibTests/WorldTests.swift
+++ b/Tests/ScintillaLibTests/WorldTests.swift
@@ -103,7 +103,8 @@ class WorldTests: XCTestCase {
         }
 
         let ray = Ray(Point(0, 0, 5), Vector(0, 0, 1))
-        let intersection = Intersection(4, s2)
+        let assignedS2 = await world.shapes[1]
+        let intersection = Intersection(4, assignedS2)
         let computations = await intersection.prepareComputations(world, ray, [intersection])
         let actualValue = await world.shadeHit(computations, MAX_RECURSIVE_CALLS)
         let expectedValue = Color(0.1, 0.1, 0.1)
@@ -295,7 +296,8 @@ class WorldTests: XCTestCase {
         }
 
         let ray = Ray(Point(0, 0, 0), Vector(0, 0, 1))
-        let intersection = Intersection(1, secondShape)
+        let assignedSecondShape = await world.shapes[1]
+        let intersection = Intersection(1, assignedSecondShape)
         let computations = await intersection.prepareComputations(world, ray, [intersection])
         let actualValue = await world.reflectedColorAt(computations, MAX_RECURSIVE_CALLS)
         let expectedValue = Color(0, 0, 0)
@@ -327,7 +329,8 @@ class WorldTests: XCTestCase {
         }
 
         let ray = Ray(Point(0, 0, -3), Vector(0, -sqrt(2)/2, sqrt(2)/2))
-        let intersection = Intersection(sqrt(2), anotherShape)
+        let assignedAnotherShape = await world.shapes[2]
+        let intersection = Intersection(sqrt(2), assignedAnotherShape)
         let computations = await intersection.prepareComputations(world, ray, [intersection])
         let actualValue = await world.shadeHit(computations, MAX_RECURSIVE_CALLS)
         let expectedValue = Color(0.87676, 0.92434, 0.82917)
@@ -379,8 +382,9 @@ class WorldTests: XCTestCase {
             additionalShape
         }
 
+        let assignedAdditionalShape = await world.shapes[2]
         let ray = Ray(Point(0, 0, -3), Vector(0, -sqrt(2)/2, sqrt(2)/2))
-        let intersection = Intersection(sqrt(2), additionalShape)
+        let intersection = Intersection(sqrt(2), assignedAdditionalShape)
         let computations = await intersection.prepareComputations(world, ray, [intersection])
         let actualValue = await world.reflectedColorAt(computations, 0)
         let expectedValue = Color.black
@@ -420,9 +424,10 @@ class WorldTests: XCTestCase {
         }
 
         let ray = Ray(Point(0, 0, -5), Vector(0, 0, 1))
+        let assignedFirstShape = await world.shapes[0]
         let allIntersections = [
-            Intersection(4, firstShape),
-            Intersection(6, firstShape),
+            Intersection(4, assignedFirstShape),
+            Intersection(6, assignedFirstShape),
         ]
         let computations = await allIntersections[0].prepareComputations(world, ray, allIntersections)
         let actualValue = await world.refractedColorAt(computations, 0)
@@ -449,9 +454,10 @@ class WorldTests: XCTestCase {
         }
 
         let ray = Ray(Point(0, 0, sqrt(2)/2), Vector(0, 1, 0))
+        let assignedFirstShape = await world.shapes[0]
         let allIntersections = [
-            Intersection(-sqrt(2)/2, firstShape),
-            Intersection(sqrt(2)/2, firstShape),
+            Intersection(-sqrt(2)/2, assignedFirstShape),
+            Intersection(sqrt(2)/2, assignedFirstShape),
         ]
         let computations = await allIntersections[1].prepareComputations(world, ray, allIntersections)
         let actualValue = await world.refractedColorAt(computations, MAX_RECURSIVE_CALLS)
@@ -495,11 +501,13 @@ class WorldTests: XCTestCase {
         }
 
         let ray = Ray(Point(0, 0, 0.1), Vector(0, 1, 0))
+        let assignedShapeA = await world.shapes[0]
+        let assignedShapeB = await world.shapes[1]
         let allIntersections = [
-            Intersection(-0.9899, shapeA),
-            Intersection(-0.4899, shapeB),
-            Intersection(0.4899, shapeB),
-            Intersection(0.9899, shapeA),
+            Intersection(-0.9899, assignedShapeA),
+            Intersection(-0.4899, assignedShapeB),
+            Intersection(0.4899, assignedShapeB),
+            Intersection(0.9899, assignedShapeA),
         ]
         let computations = await allIntersections[2].prepareComputations(world, ray, allIntersections)
         let actualValue = await world.refractedColorAt(computations, MAX_RECURSIVE_CALLS)
@@ -538,7 +546,8 @@ class WorldTests: XCTestCase {
         }
 
         let ray = Ray(Point(0, 0, -3), Vector(0, -sqrt(2)/2, sqrt(2)/2))
-        let intersection = Intersection(sqrt(2), floor)
+        let assignedFloor = await world.shapes[2]
+        let intersection = Intersection(sqrt(2), assignedFloor)
         let allIntersections = [intersection]
         let computations = await intersection.prepareComputations(world, ray, allIntersections)
         let actualValue = await world.shadeHit(computations, MAX_RECURSIVE_CALLS)
@@ -563,9 +572,10 @@ class WorldTests: XCTestCase {
         }
 
         let ray = Ray(Point(0, 0, sqrt(2)/2), Vector(0, 1, 0))
+        let assignedGlassySphere = await world.shapes[0]
         let allIntersections = [
-            Intersection(-sqrt(2)/2, glassySphere),
-            Intersection(sqrt(2)/2, glassySphere),
+            Intersection(-sqrt(2)/2, assignedGlassySphere),
+            Intersection(sqrt(2)/2, assignedGlassySphere),
         ]
         let computations = await allIntersections[1].prepareComputations(world, ray, allIntersections)
         let actualValue = await world.schlickReflectance(computations)
@@ -590,9 +600,10 @@ class WorldTests: XCTestCase {
         }
 
         let ray = Ray(Point(0, 0, 0), Vector(0, 1, 0))
+        let assignedGlassySphere = await world.shapes[0]
         let allIntersections = [
-            Intersection(-1, glassySphere),
-            Intersection(1, glassySphere),
+            Intersection(-1, assignedGlassySphere),
+            Intersection(1, assignedGlassySphere),
         ]
         let computations = await allIntersections[1].prepareComputations(world, ray, allIntersections)
         let actualValue = await world.schlickReflectance(computations)
@@ -617,7 +628,8 @@ class WorldTests: XCTestCase {
         }
 
         let ray = Ray(Point(0, 0.99, -2), Vector(0, 0, 1))
-        let intersection = Intersection(1.8589, glassySphere)
+        let assignedGlassySphere = await world.shapes[0]
+        let intersection = Intersection(1.8589, assignedGlassySphere)
         let allIntersections = [intersection]
         let computations = await intersection.prepareComputations(world, ray, allIntersections)
         let actualValue = await world.schlickReflectance(computations)
@@ -657,7 +669,8 @@ class WorldTests: XCTestCase {
         }
 
         let ray = Ray(Point(0, 0, -3), Vector(0, -sqrt(2)/2, sqrt(2)/2))
-        let intersection = Intersection(sqrt(2), floor)
+        let assignedFloor = await world.shapes[2]
+        let intersection = Intersection(sqrt(2), assignedFloor)
         let allIntersections = [intersection]
         let computations = await intersection.prepareComputations(world, ray, allIntersections)
         let actualValue = await world.shadeHit(computations, MAX_RECURSIVE_CALLS)
@@ -682,6 +695,7 @@ class WorldTests: XCTestCase {
                 .material(.solidColor(1.0, 1.0, 1.0))
             floor
         }
+        let assignedFloor = await world.shapes[1]
 
         for (direction, t, expectedColor) in [
             // Spot on the plane in the left shadow
@@ -692,7 +706,7 @@ class WorldTests: XCTestCase {
             (Vector(0, -1/sqrt(17), 4/sqrt(17)), sqrt(17), Color(0.94451, 0.94451, 0.94451)),
         ] {
             let ray = Ray(Point(0, 0, -5), direction)
-            let intersection = Intersection(t, floor)
+            let intersection = Intersection(t, assignedFloor)
             let allIntersections = [intersection]
             let computations = await intersection.prepareComputations(world, ray, allIntersections)
             let actualColor = await world.shadeHit(computations, MAX_RECURSIVE_CALLS)


### PR DESCRIPTION
This PR started out with making `Sphere` a struct instead of a class because in ScintillaApp, when `let`ting out a `Sphere` into a variable and then incorporating it multiple times in a `World` didn't work as expected because the var was a _reference_ not a value, and so transformations applied to each "instance" of the variable resulted in their all being applied _to the same instance of `Sphere`_.

But then after making `Sphere` a struct, scenes with `CSG` or `Group` shapes using a `let`ted shape _still_ didn't render properly because each usage of that variable _had the same shape ID_. That was because shapes used to be assigned an ID in the initializer, which would only happen once when `let` into a variable and then copied each time the variable was used in a `CSG` or `Group`, or `World` for that matter.

And so the solution to _that_ problem was to assign IDs to the shapes _after the initialization of `World`_. Doing so ensured that each shape node in the world graph was unique, and the functionality of `CSG`'s and `Group`'s was restored (if using `let`ted shapes).

Then my girlfriend came up with a good idea: instead of using UUIDs, use lists of integers instead, whereby the top nodes of a `World` are each assigned an ID with a value of a list of one unique integer, and then each of their children, if they have any, will have as their ID that list appended with an integer unique amongst their siblings, and so on all the way down the graph. As an example, consider this world:

```
World
    Sphere (id: [0])
    CSG (id: [1])
        CSG (id: [1, 0])
            CSG (id: [1, 0, 0])
                CSG (id: [1, 0, 0, 0])
                    Cone (id: [1, 0, 0, 0, 0]
                    Cube (id: [1, 0, 0, 0, 1])
                Cube (id: [1, 0, 0, 1])
            Cube (id: [1, 0, 1])
        Cube (id: [1, 1]
    Group (id: [2])
        Cylinder (id: [2: 0])
        Cylinder (id: [2: 1])
        Cylinder (id: [2: 2])
    Plane (id: [3])
```  

The advantage to this strategy is that parent IDs no longer need to be explicitly assigned; _they can be derived from a shape's ID directly by dropping the last element_. Employing this made ID management a _lot_ easier. Once that set of changes was made, a large amount of tests needed to be updated to get them to pass.

After staring at `World.findShape()` for a while, it became apparent that it could be vastly simplified, its counterparts in `CSG` and `Group` removed entirely, and needed to be moved into a `Shape` extension. That too made for much cleaner and more legible code.