### PR TITLE
Rename `SolidColor` to `Uniform`

### DIFF
--- a/Examples/Hourglass/Hourglass.swift
+++ b/Examples/Hourglass/Hourglass.swift
@@ -28,9 +28,9 @@ struct Hourglass: ScintillaApp {
                           fx: { (u, v) in cos(u)*sin(2*v) },
                           fy: { (u, v) in sin(v) },
                           fz: { (u, v) in sin(u)*sin(2*v) })
-            .material(.solidColor(0.9, 0.5, 0.5, .hsl))
+            .material(.uniform(0.9, 0.5, 0.5, .hsl))
         Plane()
-            .material(.solidColor(1, 1, 1))
+            .material(.uniform(1, 1, 1))
             .translate(0, -1.0, 0)
     }
 }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ struct QuickStart: ScintillaApp {
                up: Vector(0, 1, 0))
         PointLight(position: Point(-10, 10, -10))
         Sphere()
-            .material(.solidColor(1, 0, 0))
+            .material(.uniform(1, 0, 0))
     }
 }
 ```
@@ -109,7 +109,7 @@ struct SuperellipsoidScene: ScintillaApp {
         for (i, e) in [0.25, 0.5, 1.0, 2.0, 2.5].enumerated() {
             for (j, n) in [0.25, 0.5, 1.0, 2.0, 2.5].enumerated() {
                 Superellipsoid(e: e, n: n)
-                    .material(.solidColor((Double(i)+1.0)/5.0, (Double(j)+1.0)/5.0, 0.2))
+                    .material(.uniform((Double(i)+1.0)/5.0, (Double(j)+1.0)/5.0, 0.2))
                     .translate(2.5*(Double(i)-2.0), 2.5*(Double(j)-2.0), 0.0)
             }
         }
@@ -153,7 +153,7 @@ struct MyWorld: ScintillaApp {
                         topBackRight: (2, 2, 2), { x, y, z in
             x*x + y*y + z*z + sin(4*x) + sin(4*y) + sin(4*z) - 1
         })
-            .material(.solidColor(0.2, 1, 0.5))
+            .material(.uniform(0.2, 1, 0.5))
     }
 }
 ```
@@ -189,7 +189,7 @@ struct MyImplicitSurface: ScintillaApp {
                         radius: 2.0) { x, y, z in
             4.0*(φ*φ*x*x-y*y)*(φ*φ*y*y-z*z)*(φ*φ*z*z-x*x) - (1.0+2.0*φ)*(x*x+y*y+z*z-1.0)*(x*x+y*y+z*z-1.0)
         }
-            .material(.solidColor(0.9, 0.9, 0.0))
+            .material(.uniform(0.9, 0.9, 0.0))
     }
 }
 
@@ -233,9 +233,9 @@ struct Hourglass: ScintillaApp {
                           fx: { (u, v) in cos(u)*sin(2*v) },
                           fy: { (u, v) in sin(v) },
                           fz: { (u, v) in sin(u)*sin(2*v) })
-            .material(.solidColor(0.9, 0.5, 0.5, .hsl))
+            .material(.uniform(0.9, 0.5, 0.5, .hsl))
         Plane()
-            .material(.solidColor(1, 1, 1))
+            .material(.uniform(1, 1, 1))
             .translate(0, -1.0, 0)
     }
 }
@@ -270,9 +270,9 @@ struct Hourglass: ScintillaApp {
                           fx: { (u, v) in cos(u)*sin(2*v) },
                           fy: { (u, v) in sin(v) },
                           fz: { (u, v) in sin(u)*sin(2*v) })
-            .material(.solidColor(0.9, 0.5, 0.5, .hsl))
+            .material(.uniform(0.9, 0.5, 0.5, .hsl))
         Plane()
-            .material(.solidColor(1, 1, 1))
+            .material(.uniform(1, 1, 1))
             .translate(0, -1.0, 0)
     }
 }
@@ -312,9 +312,9 @@ struct Hourglass: ScintillaApp {
                           fx: { (u, v) in cos(u)*sin(2*v) },
                           fy: { (u, v) in sin(v) },
                           fz: { (u, v) in sin(u)*sin(2*v) })
-            .material(.solidColor(0.9, 0.5, 0.5, .hsl))
+            .material(.uniform(0.9, 0.5, 0.5, .hsl))
         Plane()
-            .material(.solidColor(1, 1, 1))
+            .material(.uniform(1, 1, 1))
             .translate(0, -1.0, 0)
     }
 }
@@ -361,9 +361,9 @@ struct PrismScene: ScintillaApp {
                          (-1.0, -1.0),
                          (0.0, -0.5),
                          (1.0, -1.0)])
-            .material(.solidColor(1, 0.5, 0))
+            .material(.uniform(1, 0.5, 0))
         Plane()
-            .material(.solidColor(1, 1, 1))
+            .material(.uniform(1, 1, 1))
     }
 }
 ```
@@ -399,9 +399,9 @@ struct SorScene: ScintillaApp {
                                        (2.0, 1.0),
                                        (3.0, 0.5),
                                        (6.0, 0.5)])
-            .material(.solidColor(0.5, 0.6, 0.8))
+            .material(.uniform(0.5, 0.6, 0.8))
         Plane()
-            .material(.solidColor(1, 1, 1))
+            .material(.uniform(1, 1, 1))
     }
 }
 ```
@@ -414,7 +414,7 @@ As of this writing, only the cubic spline strategy is available for interpolatin
 
 Currently materials employ either of the following color schemes:
 
-* a solid color
+* a uniform color
 * a repeating pattern
 * a color function which takes an x, y, and z values and returns a tuple representing the RGB values of a color
 
@@ -442,7 +442,7 @@ There is a default material, `SolidColor.basicMaterial()`, that can be used as a
 
 To associate a material with a `Shape`, you call the `.material()` property modifier and pass in a `Material` instance. There are three static methods that are provided as a convenience to accomplish this:
 
-* `.solidColor(_ r: Double, _ g: Double, _ b: Double)`
+* `.uniform(_ r: Double, _ g: Double, _ b: Double)`
 * `.pattern(_ pattern: Pattern)`
 * `.colorFunction(_ f: ColorFunctionType)`
 
@@ -491,7 +491,7 @@ Colors can be expressed in both RGB and HSL color spaces. By default, colors are
 ```swift
 Sphere()
     .translate(0, 1, 0)
-    .material(.solidColor(0.5, 1.0, 0.5, .hsl))
+    .material(.uniform(0.5, 1.0, 0.5, .hsl))
 ```
 
 ![](images/SolidColorHsl.png)
@@ -520,17 +520,17 @@ The implementation for CSG takes advantage of so-called result builders, a featu
 
 ```swift
 Sphere()
-    .material(.solidColor(Color(0, 0, 1)))
+    .material(.uniform(Color(0, 0, 1)))
     .difference {
         Cylinder()
-            .material(.solidColor(0, 1, 0))
+            .material(.uniform(0, 1, 0))
             .scale(0.6, 0.6, 0.6)
         Cylinder()
-            .material(.solidColor(0, 1, 0))
+            .material(.uniform(0, 1, 0))
             .scale(0.6, 0.6, 0.6)
             .rotateZ(PI/2)
         Cylinder()
-            .material(.solidColor(0, 1, 0))
+            .material(.uniform(0, 1, 0))
             .scale(0.6, 0.6, 0.6)
             .rotateX(PI/2)
     }
@@ -543,16 +543,16 @@ CSG(.difference,
     CSG(.difference,
         CSG(.difference,
             Sphere()
-                .material(.solidColor(0, 0, 1))),
+                .material(.uniform(0, 0, 1))),
             Cylinder()
-                .material(.solidColor(0, 1, 0))
+                .material(.uniform(0, 1, 0))
                 .scale(0.5, 0.5, 0.5)),
         Cylinder()
-            .material(.solidColor(0, 1, 0))
+            .material(.uniform(0, 1, 0))
             .scale(0.5, 0.5, 0.5)
             .rotateZ(PI/2)),
     Cylinder()
-        .material(.solidColor(0, 1, 0))
+        .material(.uniform(0, 1, 0))
         .scale(0.5, 0.5, 0.5)
         .rotateX(PI/2))
 ```
@@ -561,11 +561,11 @@ You can even use `for` loops in the middle of an expression to accomplish the sa
 
 ```swift
 Sphere()
-    .material(.solidColor(0, 0, 1))
+    .material(.uniform(0, 0, 1))
     .difference {
         for (thetaX, thetaZ) in [(0, 0), (0, PI/2), (PI/2, 0)] {
             Cylinder()
-                .material(.solidColor(0, 1, 0))
+                .material(.uniform(0, 1, 0))
                 .scale(0.6, 0.6, 0.6)
                 .rotateX(thetaX)
                 .rotateZ(thetaZ)
@@ -577,16 +577,16 @@ You can also chain calls to `.union()`, `.intersection()`, and `.difference()` t
 
 ```swift
 Sphere()
-    .material(.solidColor(0, 0, 1))
+    .material(.uniform(0, 0, 1))
     .intersection {
         Cube()
-            .material(.solidColor(1, 0, 0))
+            .material(.uniform(1, 0, 0))
             .scale(0.8, 0.8, 0.8)
     }
     .difference {
         for (thetaX, thetaZ) in [(0, 0), (0, PI/2), (PI/2, 0)] {
             Cylinder()
-                .material(.solidColor(0, 1, 0))
+                .material(.uniform(0, 1, 0))
                 .scale(0.5, 0.5, 0.5)
                 .rotateX(thetaX)
                 .rotateZ(thetaZ)
@@ -615,11 +615,11 @@ struct QuickStart: ScintillaApp {
                up: Vector(0, 1, 0))
         PointLight(position: Point(-10, 10, -10))
         Sphere()
-            .material(.solidColor(1, 0, 0))
+            .material(.uniform(1, 0, 0))
             .translate(-1, 0, 0)
             .rotateZ(PI/2)
         Sphere()
-            .material(.solidColor(0, 1, 0))
+            .material(.uniform(0, 1, 0))
             .translate(1, 0, 0)
             .rotateZ(PI/2)
     }
@@ -646,10 +646,10 @@ struct QuickStart: ScintillaApp {
         PointLight(position: Point(-10, 10, -10))
         Group {
             Sphere()
-                .material(.solidColor(1, 0, 0))
+                .material(.uniform(1, 0, 0))
                 .translate(-1, 0, 0)
             Sphere()
-                .material(.solidColor(0, 1, 0))
+                .material(.uniform(0, 1, 0))
                 .translate(1, 0, 0)
         }
             .rotateZ(PI/2)
@@ -676,10 +676,10 @@ struct QuickStart: ScintillaApp {
         for x in [-1.5, 1.5] {
             Group {
                 Sphere()
-                    .material(.solidColor(1, 0, 0))
+                    .material(.uniform(1, 0, 0))
                     .translate(-1, 0, 0)
                 Sphere()
-                    .material(.solidColor(0, 1, 0))
+                    .material(.uniform(0, 1, 0))
                     .translate(1, 0, 0)
             }
                 .rotateZ(PI/2)
@@ -755,9 +755,9 @@ struct MyWorld: ScintillaApp {
                   vSteps: 10)
         Sphere()
             .translate(0, 1, 0)
-            .material(.solidColor(1, 0, 0))
+            .material(.uniform(1, 0, 0))
         Plane()
-            .material(.solidColor(1, 1, 1))
+            .material(.uniform(1, 1, 1))
     }
 }
 ```
@@ -793,9 +793,9 @@ struct Cavatappi: ScintillaApp {
                           fx: { (u, v) in (2 + cos(u) + 0.1*cos(8*u))*cos(v) },
                           fy: { (u, v) in 2 + sin(u) + 0.1*sin(8*u) + 0.5*v },
                           fz: { (u, v) in (2 + cos(u) + 0.1*cos(8*u))*sin(v) })
-            .material(.solidColor(1.0, 0.8, 0))
+            .material(.uniform(1.0, 0.8, 0))
         Plane()
-            .material(.solidColor(1, 1, 1))
+            .material(.uniform(1, 1, 1))
             .translate(0, -3.0, 0)
     }
 }
@@ -823,7 +823,7 @@ struct DimlyLitScene: ScintillaApp {
         PointLight(position: Point(-10, 10, 0),
                    fadeDistance: 10)
         Sphere()
-            .material(.solidColor(1, 0.5, 0))
+            .material(.uniform(1, 0.5, 0))
         Plane()
             .translate(0, -1, 0)
     }
@@ -862,12 +862,12 @@ World {
            up: Vector(0, 1, 0))
     PointLight(position: Point(-10, 10, -10))
     Sphere()
-        .material(.solidColor(1, 0, 0))
+        .material(.uniform(1, 0, 0))
         .translate(-2, 0, 0)
     Sphere()
-        .material(.solidColor(0, 1, 0))
+        .material(.uniform(0, 1, 0))
     Sphere()
-        .material(.solidColor(0, 0, 1))
+        .material(.uniform(0, 0, 1))
         .translate(2, 0, 0)
 ```
 
@@ -900,13 +900,13 @@ struct MyWorld: ScintillaApp {
             .material(.solidColor(0, 0, 1))
             .intersection {
                 Cube()
-                    .material(.solidColor(1, 0, 0))
+                    .material(.uniform(1, 0, 0))
                     .scale(0.8, 0.8, 0.8)
             }
             .difference {
                 for (thetaX, thetaZ) in [(0, 0), (0, PI/2), (PI/2, 0)] {
                     Cylinder()
-                        .material(.solidColor(0, 1, 0))
+                        .material(.uniform(0, 1, 0))
                         .scale(0.5, 0.5, 0.5)
                         .rotateX(thetaX)
                         .rotateZ(thetaZ)
@@ -954,9 +954,9 @@ struct Cavatappi: ScintillaApp {
                           fx: { (u, v) in (2 + cos(u) + 0.1*cos(8*u))*cos(v) },
                           fy: { (u, v) in 2 + sin(u) + 0.1*sin(8*u) + 0.5*v },
                           fz: { (u, v) in (2 + cos(u) + 0.1*cos(8*u))*sin(v) })
-            .material(.solidColor(1.0, 0.8, 0))
+            .material(.uniform(1.0, 0.8, 0))
         Plane()
-            .material(.solidColor(1, 1, 1))
+            .material(.uniform(1, 1, 1))
             .translate(0, -3.0, 0)
     }
 }

--- a/Sources/ScintillaLib/Material.swift
+++ b/Sources/ScintillaLib/Material.swift
@@ -42,20 +42,20 @@ public protocol Material {
     var properties: MaterialProperties { get set }
 }
 
-extension Material where Self == SolidColor {
+extension Material where Self == Uniform {
     public static func basicMaterial() -> Self {
-        return SolidColor(1, 1, 1)
+        return Uniform(1, 1, 1)
     }
 
-    public static func solidColor(_ component0: Double,
-                                  _ component1: Double,
-                                  _ component2: Double,
-                                  _ colorSpace: ColorSpace = .rgb) -> Self {
-        return SolidColor(component0, component1, component2, colorSpace)
+    public static func uniform(_ component0: Double,
+                               _ component1: Double,
+                               _ component2: Double,
+                               _ colorSpace: ColorSpace = .rgb) -> Self {
+        return Uniform(component0, component1, component2, colorSpace)
     }
 
-    public static func solidColor(_ color: Color) -> Self {
-        return SolidColor(color.r, color.g, color.b)
+    public static func uniform(_ color: Color) -> Self {
+        return Uniform(color.r, color.g, color.b)
     }
 }
 

--- a/Sources/ScintillaLib/Uniform.swift
+++ b/Sources/ScintillaLib/Uniform.swift
@@ -5,9 +5,9 @@
 //  Created by Danielle Kefford on 12/20/22.
 //
 
-public struct SolidColor: Material {
+public struct Uniform: Material {
     var color: Color
-    public var properties = MaterialProperties()
+    public var properties: MaterialProperties
 
     public init(
         _ component1: Double,
@@ -16,13 +16,20 @@ public struct SolidColor: Material {
         _ colorSpace: ColorSpace = .rgb,
         _ properties: MaterialProperties = MaterialProperties()) {
         self.color = colorSpace.makeColor(component1, component2, component3)
+        self.properties = properties
+    }
+
+    public init(_ color: Color,
+                _ properties: MaterialProperties = MaterialProperties()) {
+        self.color = color
+        self.properties = properties
     }
 
     public func colorAt(_ object: any Shape, _ worldPoint: Point) -> Color {
         return color
     }
 
-    public func copy() -> SolidColor {
-        SolidColor(self.color.r, self.color.g, self.color.b, .rgb, self.properties)
+    public func copy() -> Uniform {
+        Uniform(self.color.r, self.color.g, self.color.b, .rgb, self.properties)
     }
 }

--- a/Tests/ScintillaLibTests/MaterialTests.swift
+++ b/Tests/ScintillaLibTests/MaterialTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 class MaterialTests: XCTestCase {
     func testLightingEyeBetweenLightAndSurface() throws {
-        let m = SolidColor.basicMaterial()
+        let m = Uniform.basicMaterial()
         let shape = Sphere().material(m)
         let position = Point(0, 0, 0)
         let eye = Vector(0, 0, -1)
@@ -22,7 +22,7 @@ class MaterialTests: XCTestCase {
     }
 
     func testLightingEyeOffsetFortyFiveDegrees() throws {
-        let m = SolidColor.basicMaterial()
+        let m = Uniform.basicMaterial()
         let shape = Sphere().material(m)
         let position = Point(0, 0, 0)
         let eye = Vector(0, sqrt(2)/2, -sqrt(2)/2)
@@ -34,7 +34,7 @@ class MaterialTests: XCTestCase {
     }
 
     func testLightingLightOffsetFortyFiveDegrees() throws {
-        let m = SolidColor.basicMaterial()
+        let m = Uniform.basicMaterial()
         let shape = Sphere().material(m)
         let position = Point(0, 0, 0)
         let eye = Vector(0, 0, -1)
@@ -46,7 +46,7 @@ class MaterialTests: XCTestCase {
     }
 
     func testLightingEyeInPathOfReflectionVector() throws {
-        let m = SolidColor.basicMaterial()
+        let m = Uniform.basicMaterial()
         let shape = Sphere().material(m)
         let position = Point(0, 0, 0)
         let eye = Vector(0, -sqrt(2)/2, -sqrt(2)/2)
@@ -58,7 +58,7 @@ class MaterialTests: XCTestCase {
     }
 
     func testLightingLightBehindSurface() throws {
-        let m = SolidColor.basicMaterial()
+        let m = Uniform.basicMaterial()
         let shape = Sphere().material(m)
         let position = Point(0, 0, 0)
         let eye = Vector(0, 0, -1)
@@ -74,7 +74,7 @@ class MaterialTests: XCTestCase {
         let position = Point(0, 0, 0)
         let eye = Vector(0, 0, -1)
         let normal = Vector(0, 0, -1)
-        let material = SolidColor.basicMaterial()
+        let material = Uniform.basicMaterial()
         let shape = Sphere().material(material)
         let actualValue = material.lighting(light, shape, position, eye, normal, 0.0)
         let expectedValue = Color(0.1, 0.1, 0.1)
@@ -100,7 +100,7 @@ class MaterialTests: XCTestCase {
     func testLightUsesIntensityToAttenuateColor() throws {
         let light = PointLight(position: Point(0, 0, -10))
         let shape = Sphere()
-            .material(.solidColor(1, 1, 1)
+            .material(.uniform(1, 1, 1)
                 .ambient(0.1)
                 .diffuse(0.9)
                 .specular(0.0)
@@ -128,7 +128,7 @@ class MaterialTests: XCTestCase {
                                   vVec: Vector(0, 1, 0),
                                   vSteps: 2,
                                   jitter: NoJitter())
-        let material: Material = .solidColor(1, 1, 1)
+        let material: Material = .uniform(1, 1, 1)
             .ambient(0.1)
             .diffuse(0.9)
             .specular(0.0)
@@ -149,7 +149,7 @@ class MaterialTests: XCTestCase {
 
     func testColorIsAttenuatedForALightWithAFadeDistance() throws {
         let light = PointLight(position: Point(0, 0, -10), fadeDistance: 5)
-        let material: Material = .solidColor(1, 1, 1)
+        let material: Material = .uniform(1, 1, 1)
             .ambient(0.1)
             .diffuse(0.9)
             .specular(0.0)

--- a/Tests/ScintillaLibTests/WorldTests.swift
+++ b/Tests/ScintillaLibTests/WorldTests.swift
@@ -25,7 +25,7 @@ func testWorld() -> World {
                up: Vector(0, 1, 0))
         PointLight(position: Point(-10, 10, -10))
         Sphere()
-            .material(SolidColor(0.8, 1.0, 0.6)
+            .material(Uniform(0.8, 1.0, 0.6)
                 .ambient(0.1)
                 .diffuse(0.7)
                 .specular(0.2)
@@ -68,7 +68,7 @@ class WorldTests: XCTestCase {
                    up: Vector(0, 1, 0))
             PointLight(position: Point(0, 0.25, 0), color: Color(1, 1, 1))
             Sphere()
-                .material(SolidColor(0.8, 1.0, 0.6)
+                .material(Uniform(0.8, 1.0, 0.6)
                     .ambient(0.1)
                     .diffuse(0.7)
                     .specular(0.2)
@@ -211,7 +211,7 @@ class WorldTests: XCTestCase {
                    up: Vector(0, 1, 0))
             areaLight
             Sphere()
-                .material(SolidColor(0.8, 1.0, 0.6)
+                .material(Uniform(0.8, 1.0, 0.6)
                     .ambient(0.1)
                     .diffuse(0.7)
                     .specular(0.2)
@@ -250,7 +250,7 @@ class WorldTests: XCTestCase {
                    up: Vector(0, 1, 0))
             areaLight
             Sphere()
-                .material(SolidColor(0.8, 1.0, 0.6)
+                .material(Uniform(0.8, 1.0, 0.6)
                     .ambient(0.1)
                     .diffuse(0.7)
                     .specular(0.2)
@@ -275,7 +275,7 @@ class WorldTests: XCTestCase {
 
     func testReflectedColorForNonreflectiveMaterial() async {
         let secondShape = Sphere()
-            .material(SolidColor(1.0, 1.0, 1.0)
+            .material(Uniform(1.0, 1.0, 1.0)
                 .ambient(1.0))
             .scale(0.5, 0.5, 0.5)
         let world = World {
@@ -287,7 +287,7 @@ class WorldTests: XCTestCase {
                    up: Vector(0, 1, 0))
             PointLight(position: Point(-10, 10, -10))
             Sphere()
-                .material(SolidColor(0.8, 1.0, 0.6)
+                .material(Uniform(0.8, 1.0, 0.6)
                     .ambient(0.1)
                     .diffuse(0.7)
                     .specular(0.2)
@@ -318,7 +318,7 @@ class WorldTests: XCTestCase {
                    up: Vector(0, 1, 0))
             PointLight(position: Point(-10, 10, -10))
             Sphere()
-                .material(SolidColor(0.8, 1.0, 0.6)
+                .material(Uniform(0.8, 1.0, 0.6)
                     .ambient(0.1)
                     .diffuse(0.7)
                     .specular(0.2)
@@ -372,7 +372,7 @@ class WorldTests: XCTestCase {
                    up: Vector(0, 1, 0))
             PointLight(position: Point(-10, 10, -10))
             Sphere()
-                .material(SolidColor(0.8, 1.0, 0.6)
+                .material(Uniform(0.8, 1.0, 0.6)
                     .ambient(0.1)
                     .diffuse(0.7)
                     .specular(0.2)
@@ -481,7 +481,7 @@ class WorldTests: XCTestCase {
         let shapeA = Sphere()
             .material(materialA)
 
-        let materialB = SolidColor.basicMaterial()
+        let materialB = Uniform.basicMaterial()
             .transparency(1.0)
             .refractive(1.5)
         let shapeB = Sphere()
@@ -522,7 +522,7 @@ class WorldTests: XCTestCase {
                 .refractive(1.5))
             .translate(0, -1, 0)
         let ball = Sphere()
-            .material(SolidColor(1, 0, 0)
+            .material(Uniform(1, 0, 0)
                 .ambient(0.5))
             .translate(0, -3.5, -0.5)
         let world = World {
@@ -534,7 +534,7 @@ class WorldTests: XCTestCase {
                    up: Vector(0, 1, 0))
             PointLight(position: Point(-10, 10, -10))
             Sphere()
-                .material(SolidColor(0.8, 1.0, 0.6)
+                .material(Uniform(0.8, 1.0, 0.6)
                     .ambient(0.1)
                     .diffuse(0.7)
                     .specular(0.2)
@@ -556,7 +556,7 @@ class WorldTests: XCTestCase {
     }
 
     func testSchlickReflectanceForTotalInternalReflection() async throws {
-        let glass = SolidColor(1.0, 1.0, 1.0)
+        let glass = Uniform(1.0, 1.0, 1.0)
             .transparency(1.0)
             .refractive(1.5)
         let glassySphere = Sphere().material(glass)
@@ -584,7 +584,7 @@ class WorldTests: XCTestCase {
     }
 
     func testSchlickReflectanceForPerpendicularRay() async throws {
-        let glass = SolidColor(1.0, 1.0, 1.0)
+        let glass = Uniform(1.0, 1.0, 1.0)
             .transparency(1.0)
             .refractive(1.5)
         let glassySphere = Sphere().material(glass)
@@ -612,7 +612,7 @@ class WorldTests: XCTestCase {
     }
 
     func testSchlickReflectanceForSmallAngleAndN2GreaterThanN1() async throws {
-        let glass = SolidColor(1.0, 1.0, 1.0)
+        let glass = Uniform(1.0, 1.0, 1.0)
             .transparency(1.0)
             .refractive(1.5)
         let glassySphere = Sphere().material(glass)
@@ -645,7 +645,7 @@ class WorldTests: XCTestCase {
                 .refractive(1.5))
             .translate(0, -1, 0)
         let ball = Sphere()
-            .material(SolidColor(1, 0, 0)
+            .material(Uniform(1, 0, 0)
                 .ambient(0.5))
             .translate(0, -3.5, -0.5)
         let world = World {
@@ -657,7 +657,7 @@ class WorldTests: XCTestCase {
                    up: Vector(0, 1, 0))
             PointLight(position: Point(-10, 10, -10))
             Sphere()
-                .material(SolidColor(0.8, 1.0, 0.6)
+                .material(Uniform(0.8, 1.0, 0.6)
                     .ambient(0.1)
                     .diffuse(0.7)
                     .specular(0.2)
@@ -692,7 +692,7 @@ class WorldTests: XCTestCase {
             // Light above and to the right of the sphere
             PointLight(position: Point(10, 10, 0))
             Sphere()
-                .material(.solidColor(1.0, 1.0, 1.0))
+                .material(.uniform(1.0, 1.0, 1.0))
             floor
         }
         let assignedFloor = await world.shapes[1]


### PR DESCRIPTION
The name for this material type has been renamed to avoid repeating the word "color" and to better differentiate its type (`Material`) from the one it has as one its properties (`Color`).