### PR TITLE
Add transformation methods to `Material`

### DIFF
--- a/Examples/CheckeredSphere/CheckeredSphere.swift
+++ b/Examples/CheckeredSphere/CheckeredSphere.swift
@@ -1,0 +1,31 @@
+//
+//  CheckeredSphere.swift
+//  ScintillaLib
+//
+//  Created by Danielle Kefford on 2/23/25.
+//
+
+import Darwin
+import ScintillaLib
+
+let checkered = Checkered3D(.white, .black, .identity)
+    .scale(0.5, 0.5, 0.5)
+
+@available(macOS 12.0, *)
+@main
+struct RainbowBall: ScintillaApp {
+
+    var world = World {
+        Camera(width: 400,
+               height: 400,
+               viewAngle: PI/3,
+               from: Point(0, 2, -5),
+               to: Point(0, 0, 0),
+               up: Vector(0, 1, 0))
+        PointLight(position: Point(-10, 10, -10))
+        Sphere()
+            .material(checkered)
+        Plane()
+            .translate(0.0, -1.0, 0.0)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -112,5 +112,9 @@ let package = Package(
             name: "TestDie",
             dependencies: ["ScintillaLib"],
             path: "Examples/TestDie"),
+        .executableTarget(
+            name: "CheckeredSphere",
+            dependencies: ["ScintillaLib"],
+            path: "Examples/CheckeredSphere"),
     ]
 )

--- a/Sources/ScintillaLib/ColorFunction.swift
+++ b/Sources/ScintillaLib/ColorFunction.swift
@@ -8,7 +8,7 @@
 public typealias ColorFunctionType = (Double, Double, Double) -> (Double, Double, Double)
 
 public struct ColorFunction: Material {
-    var transform: Matrix4
+    public var transform: Matrix4
     var inverseTransform: Matrix4
     var colorFunction: ColorFunctionType
     var colorSpace: ColorSpace

--- a/Sources/ScintillaLib/ColorFunction.swift
+++ b/Sources/ScintillaLib/ColorFunction.swift
@@ -8,8 +8,10 @@
 public typealias ColorFunctionType = (Double, Double, Double) -> (Double, Double, Double)
 
 public struct ColorFunction: Material {
-    public var transform: Matrix4
-    var inverseTransform: Matrix4
+    public var transform: Matrix4 = .identity
+    public var inverseTransform: Matrix4 = .identity
+    public var inverseTransposeTransform: Matrix4 = .identity
+
     var colorFunction: ColorFunctionType
     var colorSpace: ColorSpace
     public var properties = MaterialProperties()

--- a/Sources/ScintillaLib/ColorFunction.swift
+++ b/Sources/ScintillaLib/ColorFunction.swift
@@ -8,7 +8,12 @@
 public typealias ColorFunctionType = (Double, Double, Double) -> (Double, Double, Double)
 
 public struct ColorFunction: Material {
-    public var transform: Matrix4 = .identity
+    public var transform: Matrix4 = .identity {
+        didSet {
+            self.inverseTransform = transform.inverse()
+            self.inverseTransposeTransform = transform.inverse().transpose()
+        }
+    }
     public var inverseTransform: Matrix4 = .identity
     public var inverseTransposeTransform: Matrix4 = .identity
 

--- a/Sources/ScintillaLib/Material.swift
+++ b/Sources/ScintillaLib/Material.swift
@@ -37,9 +37,55 @@ public struct MaterialProperties {
 }
 
 public protocol Material {
+    var transform: Matrix4 { get set }
     func copy() -> Self
     func colorAt(_ object: any Shape, _ worldPoint: Point) -> Color
     var properties: MaterialProperties { get set }
+}
+
+// Property modification extensions
+extension Material {
+    public func translate(_ x: Double, _ y: Double, _ z: Double) -> Self {
+        var copy = self
+        copy.transform = .translation(x, y, z).multiply(copy.transform)
+
+        return copy
+    }
+
+    public func scale(_ x: Double, _ y: Double, _ z: Double) -> Self {
+        var copy = self
+        copy.transform = .scaling(x, y, z).multiply(copy.transform)
+
+        return copy
+    }
+
+    public func rotateX(_ t: Double) -> Self {
+        var copy = self
+        copy.transform = .rotationX(t).multiply(copy.transform)
+
+        return copy
+    }
+
+    public func rotateY(_ t: Double) -> Self {
+        var copy = self
+        copy.transform = .rotationY(t).multiply(copy.transform)
+
+        return copy
+    }
+
+    public func rotateZ(_ t: Double) -> Self {
+        var copy = self
+        copy.transform = .rotationZ(t).multiply(copy.transform)
+
+        return copy
+    }
+
+    public func shear(_ xy: Double, _ xz: Double, _ yx: Double, _ yz: Double, _ zx: Double, _ zy: Double) -> Self {
+        var copy = self
+        copy.transform = .shearing(xy, xz, yx, yz, zx, zy).multiply(copy.transform)
+
+        return copy
+    }
 }
 
 extension Material where Self == Uniform {

--- a/Sources/ScintillaLib/Material.swift
+++ b/Sources/ScintillaLib/Material.swift
@@ -38,6 +38,8 @@ public struct MaterialProperties {
 
 public protocol Material {
     var transform: Matrix4 { get set }
+    var inverseTransform: Matrix4 { get }
+    var inverseTransposeTransform: Matrix4 { get }
     func copy() -> Self
     func colorAt(_ object: any Shape, _ worldPoint: Point) -> Color
     var properties: MaterialProperties { get set }

--- a/Sources/ScintillaLib/Pattern.swift
+++ b/Sources/ScintillaLib/Pattern.swift
@@ -8,13 +8,20 @@
 import Foundation
 
 open class Pattern: Material {
-    public var transform: Matrix4
-    var inverseTransform: Matrix4
+    public var transform: Matrix4 = .identity {
+        didSet {
+            self.inverseTransform = transform.inverse()
+            self.inverseTransposeTransform = transform.inverse().transpose()
+        }
+    }
+    public var inverseTransform: Matrix4
+    public var inverseTransposeTransform: Matrix4
     public var properties = MaterialProperties()
 
     public init(_ transform: Matrix4, _ properties: MaterialProperties) {
         self.transform = transform
         self.inverseTransform = transform.inverse()
+        self.inverseTransposeTransform = transform.inverse().transpose()
     }
 
     open func copy() -> Self {

--- a/Sources/ScintillaLib/Pattern.swift
+++ b/Sources/ScintillaLib/Pattern.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 open class Pattern: Material {
-    var transform: Matrix4
+    public var transform: Matrix4
     var inverseTransform: Matrix4
     public var properties = MaterialProperties()
 

--- a/Sources/ScintillaLib/Uniform.swift
+++ b/Sources/ScintillaLib/Uniform.swift
@@ -7,6 +7,8 @@
 
 public struct Uniform: Material {
     public var transform: Matrix4 = .identity
+    public var inverseTransform: Matrix4 = .identity
+    public var inverseTransposeTransform: Matrix4 = .identity
     var color: Color
     public var properties: MaterialProperties
 

--- a/Sources/ScintillaLib/Uniform.swift
+++ b/Sources/ScintillaLib/Uniform.swift
@@ -6,6 +6,7 @@
 //
 
 public struct Uniform: Material {
+    public var transform: Matrix4 = .identity
     var color: Color
     public var properties: MaterialProperties
 


### PR DESCRIPTION
The primary thrust of this PR is to introduce transformation methods to `Material`, like the ones for `Shape`, that utilize the builder pattern so that multiple calls can be chained together to produce a single `Material` instance that carries the product of all relevant transformations. 

In order to do that, I needed to hoist the three critical properties, `transform`, inverseTransform`, and `self.inverseTransposeTransform` into the `Material` protocol, and then add property observer for `transform` for both `Pattern` and `ColorFunction`, since they cannot be attached to a protocol, only conforming classes and structs. `Uniform` doesn't need the property observer because transformations are moot.