### PR TITLE
Make `World.render()` cancellable

### DIFF
--- a/Sources/ScintillaLib/ScintillaView.swift
+++ b/Sources/ScintillaLib/ScintillaView.swift
@@ -60,8 +60,14 @@ import SwiftUI
     }
 
     func renderImage() async {
-        let canvas = await world.render(updateClosure: updateProgress)
-        self.nsImage = canvas.toNSImage()
-        canvas.save(to: self.fileName)
+        do {
+            let canvas = try await world.render(updateClosure: updateProgress)
+            self.nsImage = canvas.toNSImage()
+            canvas.save(to: self.fileName)
+        } catch is CancellationError {
+            // Do nothing!
+        } catch {
+            fatalError("Whoops! Something _really_ bad happened: \(error)")
+        }
     }
 }

--- a/Sources/ScintillaLib/World.swift
+++ b/Sources/ScintillaLib/World.swift
@@ -270,7 +270,7 @@ public actor World {
 
     public func render(
         updateClosure: @MainActor @escaping (Double, Range<Date>) -> Void
-    ) throws(CancellationError) async -> Canvas {
+    ) async throws -> Canvas {
         var renderedPixels = 0
         var percentRendered = 0.0
         let startingTime = Date()

--- a/Sources/ScintillaLib/World.swift
+++ b/Sources/ScintillaLib/World.swift
@@ -268,7 +268,9 @@ public actor World {
         Task { await updateClosure(newPercentRendered, newElapsedTime) }
     }
 
-    public func render(updateClosure: @MainActor @escaping (Double, Range<Date>) -> Void) async -> Canvas {
+    public func render(
+        updateClosure: @MainActor @escaping (Double, Range<Date>) -> Void
+    ) throws(CancellationError) async -> Canvas {
         var renderedPixels = 0
         var percentRendered = 0.0
         let startingTime = Date()
@@ -308,6 +310,8 @@ public actor World {
                 canvas.setPixel(x, y, color)
                 renderedPixels += 1
             }
+
+            try Task.checkCancellation()
             percentRendered = Double(renderedPixels)/Double(self.totalPixels)
             sendProgress(newPercentRendered: percentRendered,
                          newElapsedTime: startingTime ..< Date(),


### PR DESCRIPTION
This is a small but necessary change to allow ScintillaApp to be able to cancel a request to render an image. The `ScintillaView` component was updated accordingly and all tests pass.